### PR TITLE
Add manage routine page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "lazy-routiner",
       "version": "0.1.0",
       "dependencies": {
+        "@floating-ui/react": "^0.26.4",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.1.1",
         "clsx": "^2.0.0",
@@ -819,6 +820,54 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.2.tgz",
+      "integrity": "sha512-Ii3MrfY/GAIN3OhXNzpCKaLxHQfJF9qvwq/kEJYdqDxeIHa01K8sldugal6TmeeXl+WMvhv9cnVzUTaFFJF09A==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/react": {
+      "version": "0.26.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.26.4.tgz",
+      "integrity": "sha512-pRiEz+SiPyfTcckAtLkEf3KJ/sUbB4X4fWMcDm27HT2kfAq+dH+hMc2VoOkNaGpDE35a2PKo688ugWeHaToL3g==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.3",
+        "@floating-ui/utils": "^0.1.5",
+        "tabbable": "^6.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.4.tgz",
+      "integrity": "sha512-CF8k2rgKeh/49UrnIBs4BdxPUV6vize/Db1d/YbCLyp9GiVZ0BEwf5AiDSxJRCr6yOkGqTFHtmrULxkEfYZ7dQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
     },
     "node_modules/@headlessui/react": {
       "version": "1.7.17",
@@ -7879,6 +7928,11 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/tabbable": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/tailwindcss": {
       "version": "3.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^18"
       },
       "devDependencies": {
+        "@tailwindcss/forms": "^0.5.7",
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^14.1.2",
         "@types/jest": "^29.5.11",
@@ -1561,6 +1562,18 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.7.tgz",
+      "integrity": "sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==",
+      "dev": true,
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
       }
     },
     "node_modules/@testing-library/dom": {
@@ -6204,6 +6217,15 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@floating-ui/react": "^0.26.4",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.1",
     "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-dom": "^18"
   },
   "devDependencies": {
+    "@tailwindcss/forms": "^0.5.7",
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.11",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,27 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer utilities {
+  .text-hover-disabled {
+    color: theme('colors.gray.400');
+  }
+
+  .text-hover-active {
+    color: theme('colors.gray.700');
+  }
+
+  .text-hover-active:hover,
+  .text-active {
+    color: theme('colors.gray.900');
+  }
+}
+
+@layer components {
+  .dropdown-item {
+    padding: theme('padding[1.5]') theme('padding.4');
+  }
+}
+
 :root {
   --theme-neutral-100: #e1dcd9;
   --theme-neutral-200: #8f8681;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <GlobalNavbar />
-        <div className="mx-auto min-h-screen max-w-2xl space-y-8 bg-white pb-4 pt-20 shadow-lg shadow-black/10">
+        <div className="relative mx-auto min-h-screen max-w-2xl space-y-8 bg-white pb-4 pt-20 shadow-lg shadow-black/10">
           {children}
         </div>
       </body>

--- a/src/app/plan/[id]/page.tsx
+++ b/src/app/plan/[id]/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+import Badge, { BadgeVariant } from 'src/components/badge';
+import Button from 'src/components/button';
+import Form from 'src/components/form';
+
+const MOCK_DATA: {
+  id: string;
+  name: string;
+  variant: BadgeVariant;
+}[] = [
+  { id: '1', variant: 'blue', name: '생활' },
+  { id: '2', variant: 'yellow', name: '상식' },
+];
+
+export default function DoPlanRoutine() {
+  return (
+    <main>
+      <form>
+        <div className="space-y-8 px-10 pt-4">
+          <fieldset>
+            <Form.Legend>루틴 카테고리</Form.Legend>
+            <div className="mt-4 space-y-4">
+              {MOCK_DATA.map((badge) => (
+                <div key={badge.id} className="flex items-center gap-x-3">
+                  <Form.InputRadio id={badge.id} name="category" />
+                  <Form.Label htmlFor={badge.id}>
+                    <Badge variant={badge.variant}>{badge.name}</Badge>
+                  </Form.Label>
+                </div>
+              ))}
+            </div>
+          </fieldset>
+          <fieldset>
+            <Form.Legend>루틴을 반복할 요일</Form.Legend>
+            <div className="mt-4 grid grid-cols-4 gap-x-6 gap-y-4 sm:grid-cols-7">
+              {['일', '월', '화', '수', '목', '금', '토'].map((day) => (
+                <div key={day} className="relative flex gap-x-3 sm:col-span-1">
+                  <div className="flex h-6 items-center">
+                    <Form.InputCheckbox id={day} name={day} />
+                  </div>
+                  <Form.Label htmlFor={day}>{day}</Form.Label>
+                </div>
+              ))}
+            </div>
+          </fieldset>
+          <div>
+            <Form.Label htmlFor="name">실천할 내용</Form.Label>
+            <Form.InputText
+              id="name"
+              placeholder="자기 전에 일기 쓰기"
+              className="mt-4"
+            />
+          </div>
+        </div>
+        {/* TODO 위 블록이 충분히 길어지면 absolute 스타일을 제외히자. */}
+        {/* <div className="mt-8 flex items-center justify-end gap-x-6 border-t border-gray-900/10 px-4 pt-4"> */}
+        <div className="absolute bottom-0 left-0 right-0 flex items-center justify-end gap-x-6 border-t border-gray-900/10 p-4">
+          <Button variant="secondary" size="wmd" rounded>
+            취소
+          </Button>
+          <Button type="submit" variant="primary" size="wmd" rounded>
+            저장
+          </Button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/src/app/plan/[id]/page.tsx
+++ b/src/app/plan/[id]/page.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 import Badge, { BadgeVariant } from 'src/components/badge';
 import Button from 'src/components/button';
 import Form from 'src/components/form';
@@ -13,16 +15,38 @@ const MOCK_DATA: {
 ];
 
 export default function DoPlanRoutine() {
+  const router = useRouter();
+
+  const [category, setCategory] = useState<string>('');
+  const [days, setDays] = useState<{ [key: string]: boolean }>({});
+  const [name, setName] = useState<string>('');
+
   return (
     <main>
-      <form>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          console.log(category);
+          console.log(days);
+          console.log(name);
+          router.back();
+        }}
+      >
         <div className="space-y-8 px-10 pt-4">
           <fieldset>
             <Form.Legend>루틴 카테고리</Form.Legend>
             <div className="mt-4 space-y-4">
               {MOCK_DATA.map((badge) => (
                 <div key={badge.id} className="flex items-center gap-x-3">
-                  <Form.InputRadio id={badge.id} name="category" />
+                  <Form.InputRadio
+                    id={badge.id}
+                    name="category"
+                    value={badge.id}
+                    checked={category === badge.id}
+                    onChange={(e) => {
+                      setCategory(e.target.value);
+                    }}
+                  />
                   <Form.Label htmlFor={badge.id}>
                     <Badge variant={badge.variant}>{badge.name}</Badge>
                   </Form.Label>
@@ -33,12 +57,23 @@ export default function DoPlanRoutine() {
           <fieldset>
             <Form.Legend>루틴을 반복할 요일</Form.Legend>
             <div className="mt-4 grid grid-cols-4 gap-x-6 gap-y-4 sm:grid-cols-7">
-              {['일', '월', '화', '수', '목', '금', '토'].map((day) => (
-                <div key={day} className="relative flex gap-x-3 sm:col-span-1">
+              {['일', '월', '화', '수', '목', '금', '토'].map((d, i) => (
+                <div key={d} className="relative flex gap-x-3 sm:col-span-1">
                   <div className="flex h-6 items-center">
-                    <Form.InputCheckbox id={day} name={day} />
+                    <Form.InputCheckbox
+                      id={d}
+                      name={d}
+                      value={i}
+                      checked={days[i] || false}
+                      onChange={({ target: { value, checked } }) => {
+                        setDays((prevDays) => ({
+                          ...prevDays,
+                          [value]: checked,
+                        }));
+                      }}
+                    />
                   </div>
-                  <Form.Label htmlFor={day}>{day}</Form.Label>
+                  <Form.Label htmlFor={d}>{d}</Form.Label>
                 </div>
               ))}
             </div>
@@ -49,13 +84,22 @@ export default function DoPlanRoutine() {
               id="name"
               placeholder="자기 전에 일기 쓰기"
               className="mt-4"
+              value={name}
+              onChange={(e) => {
+                setName(e.target.value);
+              }}
             />
           </div>
         </div>
         {/* TODO 위 블록이 충분히 길어지면 absolute 스타일을 제외히자. */}
         {/* <div className="mt-8 flex items-center justify-end gap-x-6 border-t border-gray-900/10 px-4 pt-4"> */}
         <div className="absolute bottom-0 left-0 right-0 flex items-center justify-end gap-x-6 border-t border-gray-900/10 p-4">
-          <Button variant="secondary" size="wmd" rounded>
+          <Button
+            variant="secondary"
+            size="wmd"
+            rounded
+            onClick={() => router.back()}
+          >
             취소
           </Button>
           <Button type="submit" variant="primary" size="wmd" rounded>

--- a/src/app/plan/[id]/page.tsx
+++ b/src/app/plan/[id]/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import Badge, { BadgeVariant } from 'src/components/badge';
 import Button from 'src/components/button';
 import Form from 'src/components/form';
+import Toast from 'src/components/toast';
 
 const MOCK_DATA: {
   id: string;
@@ -21,20 +22,56 @@ export default function DoPlanRoutine() {
   const [days, setDays] = useState<{ [key: string]: boolean }>({});
   const [name, setName] = useState<string>('');
 
+  const [catRef, setCatRef] = useState<HTMLLegendElement | null>(null);
+  const [daysRef, setDaysRef] = useState<HTMLLegendElement | null>(null);
+  const [nameRef, setNameRef] = useState<HTMLLabelElement | null>(null);
+
+  const [categoryInvalid, setCategoryInvalid] = useState(false);
+  const [daysInvalid, setDaysInvalid] = useState(false);
+  const [nameInvalid, setNameInvalid] = useState(false);
+
+  const validate = () => {
+    let daysInvalid = true;
+    for (let day in days)
+      if (days[day]) {
+        daysInvalid = false;
+      }
+    const categoryInvalid = category === '';
+    const nameInvalid = name === '';
+
+    setCategoryInvalid(categoryInvalid);
+    setDaysInvalid(daysInvalid);
+    setNameInvalid(nameInvalid);
+    return !(categoryInvalid || daysInvalid || nameInvalid);
+  };
+
   return (
     <main>
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          console.log(category);
-          console.log(days);
-          console.log(name);
-          router.back();
+
+          if (validate()) {
+            console.log('##', category);
+            console.log('##', days);
+            console.log('##', name);
+            router.back();
+          }
         }}
       >
         <div className="space-y-8 px-10 pt-4">
           <fieldset>
-            <Form.Legend>루틴 카테고리</Form.Legend>
+            <Form.Legend ref={setCatRef}>루틴 카테고리</Form.Legend>
+            <Toast
+              show={categoryInvalid}
+              variant="error"
+              options={{
+                placement: 'right',
+                reference: catRef,
+              }}
+            >
+              하나 이상 선택해야 해요.
+            </Toast>
             <div className="mt-4 space-y-4">
               {MOCK_DATA.map((badge) => (
                 <div key={badge.id} className="flex items-center gap-x-3">
@@ -55,7 +92,17 @@ export default function DoPlanRoutine() {
             </div>
           </fieldset>
           <fieldset>
-            <Form.Legend>루틴을 반복할 요일</Form.Legend>
+            <Form.Legend ref={setDaysRef}>루틴을 반복할 요일</Form.Legend>
+            <Toast
+              show={daysInvalid}
+              variant="error"
+              options={{
+                placement: 'right',
+                reference: daysRef,
+              }}
+            >
+              하나 이상 선택해야 해요.
+            </Toast>
             <div className="mt-4 grid grid-cols-4 gap-x-6 gap-y-4 sm:grid-cols-7">
               {['일', '월', '화', '수', '목', '금', '토'].map((d, i) => (
                 <div key={d} className="relative flex gap-x-3 sm:col-span-1">
@@ -79,7 +126,19 @@ export default function DoPlanRoutine() {
             </div>
           </fieldset>
           <div>
-            <Form.Label htmlFor="name">실천할 내용</Form.Label>
+            <Form.Label htmlFor="name" ref={setNameRef}>
+              실천할 내용
+            </Form.Label>
+            <Toast
+              show={nameInvalid}
+              variant="error"
+              options={{
+                placement: 'right',
+                reference: nameRef,
+              }}
+            >
+              빈 값일 수 없어요.
+            </Toast>
             <Form.InputText
               id="name"
               placeholder="자기 전에 일기 쓰기"

--- a/src/app/plan/page.tsx
+++ b/src/app/plan/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
 import { ChevronRightIcon, PlusIcon } from '@heroicons/react/20/solid';
 import Link from 'next/link';
 import Badge, { BadgeVariant } from 'src/components/badge';
@@ -24,6 +25,8 @@ const MOCK_DATA: {
 ];
 
 export default function PlanRoutine() {
+  const router = useRouter();
+
   return (
     <main>
       <div className="flex justify-end px-6 pb-4">
@@ -31,8 +34,8 @@ export default function PlanRoutine() {
           variant="primary"
           rounded
           fullWidth
-          disabled
           className="flex items-center justify-center gap-1 font-semibold"
+          onClick={() => router.push('/plan/new')}
         >
           <PlusIcon className="-ml-1 h-5 w-5" />
           루틴 등록하기
@@ -51,7 +54,7 @@ export default function PlanRoutine() {
               <Badge variant={badge.variant}>{badge.name}</Badge>
               <RoutineList.ItemBody>
                 {({ ExpandedPane }) => (
-                  <Link href="/plan">
+                  <Link href={`/plan/${routine.id}`}>
                     {routine.name}
                     <ExpandedPane />
                   </Link>

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -1,11 +1,7 @@
 'use client';
 
-import { Menu, Transition } from '@headlessui/react';
 import { CheckIcon, EllipsisVerticalIcon } from '@heroicons/react/24/outline';
-import clsx from 'clsx';
-import { Fragment } from 'react';
 import Badge, { BadgeVariant } from 'src/components/badge';
-import Button from 'src/components/button';
 import Dropdown from 'src/components/dropdown';
 import RoutineList from 'src/components/routine-list';
 
@@ -60,7 +56,9 @@ export default function RoutineToday() {
                 <Dropdown.Menu>
                   {['완료하기', '오늘은 건너뛰기', '오늘 안 하기'].map(
                     (name) => (
-                      <Dropdown.Item key={name}>{name}</Dropdown.Item>
+                      <Dropdown.ButtonItem key={name}>
+                        {name}
+                      </Dropdown.ButtonItem>
                     ),
                   )}
                 </Dropdown.Menu>
@@ -78,11 +76,9 @@ export default function RoutineToday() {
                   />
                 </Dropdown.Button>
                 <Dropdown.Menu>
-                  {['수정'].map((name) => (
-                    <Dropdown.Item key={name} disabled>
-                      {name}
-                    </Dropdown.Item>
-                  ))}
+                  <Dropdown.LinkItem href="#" disabled>
+                    수정
+                  </Dropdown.LinkItem>
                 </Dropdown.Menu>
               </Dropdown>
             </RoutineList.ItemTail>

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -76,8 +76,8 @@ export default function RoutineToday() {
                   />
                 </Dropdown.Button>
                 <Dropdown.Menu>
-                  <Dropdown.LinkItem href="#" disabled>
-                    수정
+                  <Dropdown.LinkItem href={`/plan/${routine.id}`}>
+                    수정하기
                   </Dropdown.LinkItem>
                 </Dropdown.Menu>
               </Dropdown>

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -6,13 +6,13 @@ const BUTTON_STYLES = {
     'bg-theme-neutral-200 text-white hover:bg-theme-neutral-200/90 focus-visible:outline-theme-neutral-200',
   secondary:
     'bg-white text-gray-900 hover:bg-gray-50 focus-visible:outline-gray-300',
-  clear: 'text-gray-500 hover:text-gray-600',
+  clear: 'text-hover-active',
 };
 
 const DISABLED_BUTTON_STYLES = {
   primary: 'bg-theme-neutral-200/80 text-white',
-  secondary: 'bg-gray-100 text-gray-400',
-  clear: 'text-gray-400',
+  secondary: 'bg-gray-100 text-hover-disabled',
+  clear: 'text-hover-disabled',
 };
 
 const BORDER_STYLES = {
@@ -24,6 +24,7 @@ const BORDER_STYLES = {
 const SIZE_STYLES = {
   sm: 'p-1.5 text-xs',
   md: 'p-2 text-sm',
+  unset: '',
 };
 
 export interface ButtonProps

--- a/src/components/button.tsx
+++ b/src/components/button.tsx
@@ -24,6 +24,7 @@ const BORDER_STYLES = {
 const SIZE_STYLES = {
   sm: 'p-1.5 text-xs',
   md: 'p-2 text-sm',
+  wmd: 'px-3 py-2 text-sm',
   unset: '',
 };
 

--- a/src/components/dropdown.tsx
+++ b/src/components/dropdown.tsx
@@ -1,7 +1,8 @@
 import { Menu, MenuItemProps, Transition } from '@headlessui/react';
 import clsx from 'clsx';
-import { Fragment, type PropsWithChildren } from 'react';
+import React, { Fragment } from 'react';
 import Button, { ButtonProps } from 'src/components/button';
+import Link, { LinkProps } from 'next/link';
 
 function DropdownRoot({ children }: React.PropsWithChildren) {
   return (
@@ -43,22 +44,21 @@ function DropdownMenu({ children }: React.PropsWithChildren) {
   );
 }
 
-function DropdownItem<TTag extends React.ElementType>({
+function DropdownItemRoot<TTag extends React.ElementType>({
   children,
   disabled,
   ...props
-}: PropsWithChildren<MenuItemProps<TTag>>) {
+}: React.PropsWithChildren<MenuItemProps<TTag>>) {
   return (
     <Menu.Item disabled={disabled} {...props}>
       {({ active }) => (
         <li
           className={clsx(
-            'block whitespace-nowrap px-4 py-1.5 text-sm',
-            disabled && 'cursor-default text-gray-400',
-            !disabled && 'cursor-pointer',
+            'block whitespace-nowrap text-sm',
+            disabled && 'text-hover-disabled cursor-default',
+            !disabled && 'text-hover-active cursor-pointer',
             !disabled && {
-              'bg-gray-100 text-gray-900': active,
-              'text-gray-700': !active,
+              'text-active bg-gray-100': active,
             },
           )}
         >
@@ -69,10 +69,60 @@ function DropdownItem<TTag extends React.ElementType>({
   );
 }
 
+function DropdownItem({ children }: React.PropsWithChildren) {
+  return (
+    // TODO
+    <DropdownItemRoot>{children}</DropdownItemRoot>
+  );
+}
+
+function DropdownButtonItem({
+  disabled,
+  children,
+  ...props
+}: React.PropsWithChildren<React.ButtonHTMLAttributes<HTMLButtonElement>>) {
+  return (
+    <DropdownItemRoot disabled={disabled}>
+      <Button
+        variant="clear"
+        size="unset"
+        className="dropdown-item cursor- text-left"
+        fullWidth
+        disabled={disabled}
+        {...props}
+      >
+        {children}
+      </Button>
+    </DropdownItemRoot>
+  );
+}
+
+function DropdownLinkItem({
+  href,
+  disabled,
+  children,
+}: LinkProps & React.HTMLProps<HTMLAnchorElement>) {
+  return (
+    <DropdownItemRoot disabled={disabled}>
+      <Link
+        href={href}
+        className="dropdown-item block"
+        onClick={(e) => {
+          if (disabled) e.preventDefault();
+        }}
+      >
+        {children}
+      </Link>
+    </DropdownItemRoot>
+  );
+}
+
 const Dropdown = Object.assign(DropdownRoot, {
   Button: DropdownButton,
   Menu: DropdownMenu,
   Items: DropdownMenu,
   Item: DropdownItem,
+  ButtonItem: DropdownButtonItem,
+  LinkItem: DropdownLinkItem,
 });
 export default Dropdown;

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -1,0 +1,90 @@
+import clsx from 'clsx';
+
+function FormRoot({ children }: React.PropsWithChildren) {
+  return <>{children}</>;
+}
+
+function FormInput({
+  id,
+  name,
+  className,
+  ...props
+}: React.PropsWithChildren<React.InputHTMLAttributes<HTMLInputElement>>) {
+  return (
+    <input
+      id={id}
+      name={name || id}
+      className={clsx(
+        'border-gray-300 text-theme-neutral-200 focus:ring-theme-neutral-200',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function FormInputText({
+  id,
+  name,
+  className,
+  ...props
+}: React.InputHTMLAttributes<HTMLInputElement>) {
+  return (
+    <div
+      className={clsx(
+        'flex w-full rounded-md shadow-sm ring-1 ring-inset ring-gray-300 focus-within:ring-2 focus-within:ring-inset focus-within:ring-theme-neutral-200',
+        className,
+      )}
+    >
+      <input
+        type="text"
+        id={id}
+        name={name || id}
+        className="block flex-1 border-0 bg-transparent py-1.5 pl-3 text-gray-900 placeholder:text-gray-400 focus:ring-0 sm:text-sm sm:leading-6"
+        {...props}
+      />
+    </div>
+  );
+}
+
+function FormInputCheckbox({
+  ...props
+}: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <FormInput type="checkbox" className="h-4 w-4 rounded" {...props} />;
+}
+
+function FormInputRadio({
+  ...props
+}: React.InputHTMLAttributes<HTMLInputElement>) {
+  return <FormInput type="radio" className="h-4 w-4" {...props} />;
+}
+
+function FormLabel({
+  children,
+  ...props
+}: React.PropsWithChildren<React.LabelHTMLAttributes<HTMLLabelElement>>) {
+  return (
+    <label className="text-sm font-medium leading-6 text-gray-900" {...props}>
+      {children}
+    </label>
+  );
+}
+
+function FormLegend({
+  children,
+}: React.PropsWithChildren<React.HTMLAttributes<HTMLElement>>) {
+  return (
+    <legend className="text-sm font-semibold leading-6 text-gray-900">
+      {children}
+    </legend>
+  );
+}
+
+const Form = Object.assign(FormRoot, {
+  InputText: FormInputText,
+  InputCheckbox: FormInputCheckbox,
+  InputRadio: FormInputRadio,
+  Label: FormLabel,
+  Legend: FormLegend,
+});
+export default Form;

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { forwardRef } from 'react';
 
 function FormRoot({ children }: React.PropsWithChildren) {
   return <>{children}</>;
@@ -59,22 +60,37 @@ function FormInputRadio({
   return <FormInput type="radio" className="h-4 w-4" {...props} />;
 }
 
-function FormLabel({
-  children,
-  ...props
-}: React.PropsWithChildren<React.LabelHTMLAttributes<HTMLLabelElement>>) {
+function FormLabel(
+  {
+    children,
+    ...props
+  }: React.PropsWithChildren<React.LabelHTMLAttributes<HTMLLabelElement>>,
+  ref: React.LegacyRef<HTMLLabelElement> | null,
+) {
   return (
-    <label className="text-sm font-medium leading-6 text-gray-900" {...props}>
+    <label
+      className="inline-block text-sm font-medium leading-6 text-gray-900"
+      ref={ref}
+      {...props}
+    >
       {children}
     </label>
   );
 }
 
-function FormLegend({
-  children,
-}: React.PropsWithChildren<React.HTMLAttributes<HTMLElement>>) {
+function FormLegend(
+  {
+    children,
+    ...props
+  }: React.PropsWithChildren<React.HTMLAttributes<HTMLLegendElement>>,
+  ref: React.LegacyRef<HTMLLegendElement> | null,
+) {
   return (
-    <legend className="text-sm font-semibold leading-6 text-gray-900">
+    <legend
+      className="text-sm font-semibold leading-6 text-gray-900"
+      ref={ref}
+      {...props}
+    >
       {children}
     </legend>
   );
@@ -84,7 +100,7 @@ const Form = Object.assign(FormRoot, {
   InputText: FormInputText,
   InputCheckbox: FormInputCheckbox,
   InputRadio: FormInputRadio,
-  Label: FormLabel,
-  Legend: FormLegend,
+  Label: forwardRef(FormLabel),
+  Legend: forwardRef(FormLegend),
 });
 export default Form;

--- a/src/components/global-navbar.tsx
+++ b/src/components/global-navbar.tsx
@@ -104,11 +104,10 @@ function GlobalNavItem({
       className={clsx(
         '-mx-3 my-1.5 flex place-items-center gap-3 rounded-md p-3 text-base leading-7 md:gap-1.5',
         {
-          'cursor-default text-gray-400': disabled,
-          'hover:bg-theme-neutral-300/20 text-gray-500 hover:text-gray-600':
-            selectable,
+          'text-hover-disabled cursor-default': disabled,
+          'hover:bg-theme-neutral-300/20 text-hover-active': selectable,
           'font-normal': !active,
-          'font-medium text-gray-800': active,
+          'text-active font-medium': active,
         },
       )}
       onClick={(e) => {

--- a/src/components/toast.tsx
+++ b/src/components/toast.tsx
@@ -1,0 +1,64 @@
+import { offset, useFloating } from '@floating-ui/react';
+import type { Placement } from '@floating-ui/utils';
+import { Transition } from '@headlessui/react';
+import clsx from 'clsx';
+import { Fragment } from 'react';
+
+const Body = {
+  warn: 'bg-amber-300 text-slate-900',
+  error: 'bg-red-500 text-slate-50',
+};
+
+type ToastProps = React.PropsWithChildren<{
+  show: boolean;
+  variant: 'warn' | 'error';
+  options: {
+    placement: Placement;
+    reference: Element | null;
+  };
+}>;
+
+export default function Toast({
+  show,
+  variant,
+  options,
+  children,
+}: ToastProps) {
+  const { floatingStyles, y, refs } = useFloating({
+    placement: options.placement,
+    middleware: [
+      offset({
+        mainAxis: 10,
+      }),
+    ],
+    elements: options && {
+      reference: options.reference,
+    },
+    transform: false,
+  });
+
+  return (
+    <Transition
+      as={Fragment}
+      show={show}
+      enter="transition ease-out duration-200"
+      enterFrom="opacity-0 translate-y-3"
+      enterTo="opacity-100 translate-y-0"
+      leave="transition ease-in duration-150"
+      leaveFrom="opacity-100 translate-y-0"
+      leaveTo="opacity-0 translate-y-3"
+    >
+      <div
+        role="alert"
+        ref={refs.setFloating}
+        style={floatingStyles}
+        className={clsx(
+          'inline-flex items-center rounded-3xl px-3 py-1 text-xs',
+          Body[variant],
+        )}
+      >
+        {children}
+      </div>
+    </Transition>
+  );
+}

--- a/src/hooks/useInputReducer.ts
+++ b/src/hooks/useInputReducer.ts
@@ -1,0 +1,75 @@
+import { useReducer, useState } from 'react';
+
+type State<T> = {
+  value: T;
+  invalid: boolean;
+};
+
+type ReducerType = 'SET_REF' | 'CHANGE_VALUE' | 'VALIDATE';
+const reducer = <T>(
+  prev: State<T>,
+  action: {
+    type: ReducerType;
+    value: T;
+    invalid?: boolean;
+  },
+) => {
+  switch (action.type) {
+    case 'CHANGE_VALUE': {
+      return {
+        ...prev,
+        value: action.value,
+      };
+    }
+    case 'VALIDATE': {
+      return {
+        ...prev,
+        invalid: action.invalid || false,
+      };
+    }
+    default: {
+      return prev;
+    }
+  }
+};
+
+export function useInputReducer<T, E = HTMLElement>(
+  initialValue: T,
+): [
+  { ref: E | null } & State<T>,
+  {
+    setRef: React.Dispatch<React.SetStateAction<E | null>>;
+    change: (value: T) => void;
+    validate: (fn: (value: T) => boolean) => boolean;
+  },
+] {
+  const [ref, setRef] = useState<E | null>(null);
+  const [state, dispatch] = useReducer(reducer<T>, {
+    value: initialValue,
+    invalid: false,
+  });
+
+  return [
+    {
+      ref,
+      ...state,
+    },
+    {
+      setRef,
+      change: (value) =>
+        dispatch({
+          type: 'CHANGE_VALUE',
+          value,
+        }),
+      validate: (fn) => {
+        const valid = fn(state.value);
+        dispatch({
+          type: 'VALIDATE',
+          value: state.value,
+          invalid: !valid,
+        });
+        return valid;
+      },
+    },
+  ];
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -26,6 +26,6 @@ const config: Config = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('@tailwindcss/forms')],
 };
 export default config;


### PR DESCRIPTION
- 루틴 추가, 편집 페이지 생성
- 드랍다운 아이템 컴포넌트 목적에 맞게 구분
- 폼 입력 요소 상태(Ref, 입력값, 유효성 검사 결과)를 저장하는 hook 생성
- tailwind `@layer`를 사용한 스타일 커스터마이징

## 스크린샷
<img src="https://github.com/j2e4/routiner/assets/40452288/3b9f0e46-456a-4544-a81c-067cecd4c3a4" alt="desktop" width="640" />
<img src="https://github.com/j2e4/routiner/assets/40452288/764deadd-498b-433a-8030-63a79cd414bb" alt="mobile" width="320" />
