### PR TITLE
Request categories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@floating-ui/react": "^0.26.4",
         "@headlessui/react": "^1.7.17",
         "@heroicons/react": "^2.1.1",
+        "@tanstack/react-query": "^5.17.19",
+        "@tanstack/react-query-devtools": "^5.17.21",
         "clsx": "^2.0.0",
         "next": "14.0.4",
         "react": "^18",
@@ -1623,6 +1625,55 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.17.19",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.17.19.tgz",
+      "integrity": "sha512-Lzw8FUtnLCc9Jwz0sw9xOjZB+/mCCmJev38v2wHMUl/ioXNIhnNWeMxu0NKUjIhAd62IRB3eAtvxAGDJ55UkyA==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.17.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.17.21.tgz",
+      "integrity": "sha512-WWfcnNjTEqcuAS5GyKkVGkseuES6yd197MJWGImBu+MoCjWPqxSXKCCfm+utSXJauJUGm7xoMmhqCphiQdjf8w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.17.19",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.17.19.tgz",
+      "integrity": "sha512-qaQENB6/03Gj3dFZGvdmUoqeUGlGm7P1p0RmaR04Bf1Ib1T9lLGimcC9T3oCFbrx0b2ZF21ngjFZNjj9uPJMcg==",
+      "dependencies": {
+        "@tanstack/query-core": "5.17.19"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.17.21",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.17.21.tgz",
+      "integrity": "sha512-Ri1AuWpN67eyPdMTlPxx1TMGNUaxTHrGv0ll0S20ZObz/Xms5wfANV3c6OX0HZTY0igudP1k5jpRLXNkd249mg==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.17.21"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.17.19",
+        "react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "@floating-ui/react": "^0.26.4",
     "@headlessui/react": "^1.7.17",
     "@heroicons/react": "^2.1.1",
+    "@tanstack/react-query": "^5.17.19",
+    "@tanstack/react-query-devtools": "^5.17.21",
     "clsx": "^2.0.0",
     "next": "14.0.4",
     "react": "^18",

--- a/src/app/category/[id]/page.tsx
+++ b/src/app/category/[id]/page.tsx
@@ -2,7 +2,6 @@ import { revalidateTag } from 'next/cache';
 import { permanentRedirect } from 'next/navigation';
 import RoutineCategoryForm from 'src/app/category/form';
 import { getFetch, putFetch } from 'src/services/fetch';
-import { CategoryTheme } from 'types/category';
 
 export default async function RoutineCategoryUpdatePage({
   params: { id },
@@ -17,11 +16,19 @@ export default async function RoutineCategoryUpdatePage({
   async function update(formData: FormData) {
     'use server';
 
-    const response = await putFetch(`/category/${id}`, {
-      id,
-      name: formData.get('routiner-category-name') as string,
-      theme: formData.get('routiner-routine-category') as CategoryTheme,
-    });
+    const response = await putFetch(
+      `/category/${id}`,
+      {
+        id,
+        name: formData.get('routiner-category-name'),
+        theme: formData.get('routiner-routine-category'),
+      },
+      {
+        next: {
+          tags: ['category', id],
+        },
+      },
+    );
 
     if (response.ok) {
       revalidateTag(id);

--- a/src/app/category/[id]/page.tsx
+++ b/src/app/category/[id]/page.tsx
@@ -13,7 +13,7 @@ export default function RoutineCategoryUpdatePage() {
       <RoutineCategoryForm
         category={{
           id: '1',
-          theme: 'blue',
+          theme: 'BLUE',
           name: '생활',
         }}
         onSubmit={handleSubmit}

--- a/src/app/category/form.tsx
+++ b/src/app/category/form.tsx
@@ -1,3 +1,6 @@
+'use client';
+
+import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 import Badge, { BADGE_STYLES, BadgeVariant } from 'src/components/badge';
@@ -5,18 +8,18 @@ import Button from 'src/components/button';
 import Form from 'src/components/form';
 import Toast from 'src/components/toast';
 import { useInputReducer } from 'src/hooks/useInputReducer';
-import { CategoryInput, CategoryTheme } from 'types/category';
+import { Category, CategoryTheme } from 'types/category';
 
 const PLACEHOLDER = '건강';
 const BADGE_VARIANTS = Object.keys(BADGE_STYLES) as BadgeVariant[];
 
 type RoutineCategoryFormProps = {
-  category?: CategoryInput;
-  onSubmit: (input: CategoryInput) => void;
-};
+  category?: Category;
+} & React.FormHTMLAttributes<HTMLFormElement>;
 export default function RoutineCategoryForm({
   category,
   onSubmit,
+  ...props
 }: RoutineCategoryFormProps) {
   const router = useRouter();
 
@@ -49,19 +52,21 @@ export default function RoutineCategoryForm({
     ].every((valid) => valid);
   };
 
-  const handleSubmit = () => {
-    if (validate()) {
-      onSubmit({
-        id: category?.id,
-        name: name.value,
-        theme: theme.value,
-      });
-      router.back();
+  const queryClient = useQueryClient();
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    if (!validate()) {
+      e.preventDefault();
+      return;
     }
+
+    await queryClient.invalidateQueries({
+      queryKey: ['categories'],
+    });
+    if (onSubmit !== undefined) onSubmit(e);
   };
 
   return (
-    <Form onSubmit={handleSubmit}>
+    <Form onSubmit={handleSubmit} {...props}>
       <div>
         <Form.Label
           htmlFor="routiner-category-name"

--- a/src/app/category/new/page.tsx
+++ b/src/app/category/new/page.tsx
@@ -1,16 +1,25 @@
-'use client';
-
+import { permanentRedirect } from 'next/navigation';
 import RoutineCategoryForm from 'src/app/category/form';
-import { CategoryInput } from 'types/category';
+import { postFetch } from 'src/services/fetch';
+import { CategoryTheme } from 'types/category';
 
 export default function RoutineCategoryCreatePage() {
-  const handleSubmit = (input: CategoryInput) => {
-    console.log('create', input);
-  };
+  async function create(formData: FormData) {
+    'use server';
+
+    const response = await postFetch('/category', {
+      name: formData.get('routiner-category-name') as string,
+      theme: formData.get('routiner-routine-category') as CategoryTheme,
+    });
+
+    if (response.ok) {
+      permanentRedirect('/setting');
+    } else throw new Error(await response.json());
+  }
 
   return (
     <main>
-      <RoutineCategoryForm onSubmit={handleSubmit} />
+      <RoutineCategoryForm action={create} />
     </main>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,10 @@
 import 'src/app/globals.css';
+
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import GlobalNavbar from 'src/components/global-navbar';
-import type { Metadata } from 'next';
+import GlobalQueryClientProvider from 'src/services/server-state/query-client-provider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -20,7 +23,10 @@ export default function RootLayout({
       <body className={inter.className}>
         <GlobalNavbar />
         <div className="relative mx-auto min-h-screen max-w-2xl space-y-8 bg-white pt-16 shadow-lg shadow-black/10">
-          {children}
+          <GlobalQueryClientProvider>
+            {children}
+            <ReactQueryDevtools />
+          </GlobalQueryClientProvider>
         </div>
       </body>
     </html>

--- a/src/app/plan/form.tsx
+++ b/src/app/plan/form.tsx
@@ -8,8 +8,8 @@ import { Category } from 'types/category';
 import { RoutineInput } from 'types/routine';
 
 const MOCK_DATA: Category[] = [
-  { id: '1', theme: 'blue', name: '생활' },
-  { id: '2', theme: 'yellow', name: '상식' },
+  { id: '1', theme: 'BLUE', name: '생활' },
+  { id: '2', theme: 'YELLOW', name: '상식' },
 ];
 
 type RoutinePlanFormProps = {

--- a/src/app/plan/form.tsx
+++ b/src/app/plan/form.tsx
@@ -53,9 +53,11 @@ export default function RoutinePlanForm({
     ].every((valid) => valid);
   };
 
-  const handleSubmit = () => {
-    const valid = validate();
-    if (!valid) return;
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    if (!validate()) {
+      e.preventDefault();
+      return;
+    }
 
     const repeatDays: number[] = [];
     for (const day in days.value)

--- a/src/app/plan/page.tsx
+++ b/src/app/plan/page.tsx
@@ -15,12 +15,12 @@ const MOCK_DATA: {
   {
     id: '1',
     name: '챌린저스 기상 미션하기',
-    badge: { variant: 'blue', name: '생활' },
+    badge: { variant: 'BLUE', name: '생활' },
   },
   {
     id: '2',
     name: '뉴스레터 읽기',
-    badge: { variant: 'yellow', name: '상식' },
+    badge: { variant: 'YELLOW', name: '상식' },
   },
 ];
 

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -13,12 +13,12 @@ const MOCK_DATA: {
   {
     id: '1',
     name: '챌린저스 기상 미션하기',
-    badge: { variant: 'blue', name: '생활' },
+    badge: { variant: 'BLUE', name: '생활' },
   },
   {
     id: '2',
     name: '뉴스레터 읽기',
-    badge: { variant: 'yellow', name: '상식' },
+    badge: { variant: 'YELLOW', name: '상식' },
   },
 ];
 

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -14,8 +14,6 @@ const MOCK_DATA: {
   name: string;
   variant: BadgeVariant;
 }[] = [
-  { id: '1', variant: 'blue', name: '생활' },
-  { id: '2', variant: 'yellow', name: '상식' },
 ];
 
 export default function SettingRootPage() {

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -13,7 +13,11 @@ import { getFetch } from 'src/services/fetch';
 import { Category } from 'types/category';
 
 function getList(): Promise<Category[]> {
-  return getFetch('/category');
+  return getFetch('/category', {
+    next: {
+      tags: ['categories'],
+    },
+  });
 }
 
 export default function SettingRootPage() {

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -1,24 +1,30 @@
 'use client';
 
 import { ChevronRightIcon } from '@heroicons/react/20/solid';
+import { useQuery } from '@tanstack/react-query';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import Badge, { BadgeVariant } from 'src/components/badge';
+import Badge from 'src/components/badge';
 import Button from 'src/components/button';
 import Dialog from 'src/components/dialog';
 import List from 'src/components/list';
+import { getFetch } from 'src/services/fetch';
+import { Category } from 'types/category';
 
-const MOCK_DATA: {
-  id: string;
-  name: string;
-  variant: BadgeVariant;
-}[] = [
-];
+function getList(): Promise<Category[]> {
+  return getFetch('/category');
+}
 
 export default function SettingRootPage() {
   const router = useRouter();
   const [categoryListOpened, setCategoryListOpened] = useState(false);
+
+  const { data: categories = [], isPending } = useQuery({
+    queryKey: ['categories'],
+    queryFn: getList,
+    enabled: categoryListOpened,
+  });
 
   return (
     <main>
@@ -45,13 +51,19 @@ export default function SettingRootPage() {
       </List>
       <Dialog open={categoryListOpened} onClose={setCategoryListOpened}>
         <Dialog.Header as="h3">루틴 카테고리 관리</Dialog.Header>
-        <List border="y">
-          {MOCK_DATA.map((category) => (
+        <List border="y" className="h-48">
+          {isPending &&
+            Array.from({ length: 3 }, (_, i) => `pulse-${i}`).map((v) => (
+              <List.Item key={v} className="h-16 animate-pulse">
+                <List.ItemBody className="my-1.5 h-3 rounded-lg bg-slate-200" />
+              </List.Item>
+            ))}
+          {categories.map((category) => (
             <List.Item key={category.id} hoverable>
               <List.ItemBody>
                 {({ Filler }) => (
                   <Link href={`/category/${category.id}`}>
-                    <Badge variant={category.variant}>{category.name}</Badge>
+                    <Badge variant={category.theme}>{category.name}</Badge>
                     <Filler />
                   </Link>
                 )}

--- a/src/components/badge.tsx
+++ b/src/components/badge.tsx
@@ -2,14 +2,14 @@ import clsx from 'clsx';
 import type { HTMLAttributes } from 'react';
 
 export const BADGE_STYLES = {
-  gray: 'bg-gray-50 text-gray-600 ring-gray-500/10',
-  red: 'bg-red-50 text-red-700 ring-red-600/10',
-  yellow: 'bg-yellow-50 text-yellow-800 ring-yellow-600/20',
-  green: 'bg-green-50 text-green-700 ring-green-600/20',
-  blue: 'bg-blue-50 text-blue-700 ring-blue-700/10',
-  indigo: 'bg-indigo-50 text-indigo-700 ring-indigo-700/10',
-  purple: 'bg-purple-50 text-purple-700 ring-purple-700/10',
-  pink: 'bg-pink-50 text-pink-700 ring-pink-700/10',
+  GRAY: 'bg-gray-50 text-gray-600 ring-gray-500/10',
+  RED: 'bg-red-50 text-red-700 ring-red-600/10',
+  YELLOW: 'bg-yellow-50 text-yellow-800 ring-yellow-600/20',
+  GREEN: 'bg-green-50 text-green-700 ring-green-600/20',
+  BLUE: 'bg-blue-50 text-blue-700 ring-blue-700/10',
+  INDIGO: 'bg-indigo-50 text-indigo-700 ring-indigo-700/10',
+  PURPLE: 'bg-purple-50 text-purple-700 ring-purple-700/10',
+  PINK: 'bg-pink-50 text-pink-700 ring-pink-700/10',
 };
 
 export type BadgeVariant = keyof typeof BADGE_STYLES;
@@ -18,7 +18,7 @@ interface BadgeProps extends HTMLAttributes<HTMLSpanElement> {
   variant?: BadgeVariant;
 }
 
-export default function Badge({ variant = 'gray', children }: BadgeProps) {
+export default function Badge({ variant = 'GRAY', children }: BadgeProps) {
   return (
     <span
       className={clsx(

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -4,15 +4,10 @@ import Button from 'src/components/button';
 
 function FormRoot({
   children,
-  onSubmit,
+  ...props
 }: React.PropsWithChildren<React.FormHTMLAttributes<HTMLFormElement>>) {
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        if (onSubmit !== undefined) onSubmit(e);
-      }}
-    >
+    <form {...props}>
       <div className="space-y-8 px-10 pt-8">{children}</div>
     </form>
   );
@@ -100,7 +95,7 @@ function FormLegend(
 ) {
   return (
     <legend
-      className="text-sm font-semibold leading-6 text-gray-900"
+      className="text-sm font-medium leading-6 text-gray-900"
       ref={ref}
       {...props}
     >

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -1,20 +1,25 @@
 import clsx from 'clsx';
-import HoverableProvider from 'src/contexts/hoverable/hoverable-provider';
-import { CallableChildren } from 'types/props';
-import { useHoverable } from 'src/hooks/useHoverable';
 import React from 'react';
+import HoverableProvider from 'src/contexts/hoverable/hoverable-provider';
+import { useHoverable } from 'src/hooks/useHoverable';
+import { CallableChildren } from 'types/props';
 
 type ListRootProps = React.PropsWithChildren<{
   border: 't' | 'b' | 'y';
+  className?: string;
 }>;
-function ListRoot({ border = 'y', children }: ListRootProps) {
+function ListRoot({ border = 'y', children, className }: ListRootProps) {
   return (
     <ul
-      className={clsx('divide-y border-gray-200', {
-        'border-t': border === 't',
-        'border-b': border === 'b',
-        'border-y': border === 'y',
-      })}
+      className={clsx(
+        'divide-y overflow-y-auto border-gray-200',
+        {
+          'border-t': border === 't',
+          'border-b': border === 'b',
+          'border-y': border === 'y',
+        },
+        className,
+      )}
     >
       {children}
     </ul>
@@ -23,14 +28,19 @@ function ListRoot({ border = 'y', children }: ListRootProps) {
 
 type ListItemProps = React.PropsWithChildren<{
   hoverable?: boolean;
+  className?: string;
 }>;
-function ListItem({ children, hoverable = false }: ListItemProps) {
+function ListItem({ children, className, hoverable = false }: ListItemProps) {
   return (
     <HoverableProvider hoverable={hoverable}>
       <li
-        className={clsx('flex px-3.5 py-5 md:px-8', {
-          'relative hover:bg-gray-50': hoverable,
-        })}
+        className={clsx(
+          'flex px-3.5 py-5 md:px-8',
+          {
+            'relative hover:bg-gray-50': hoverable,
+          },
+          className,
+        )}
       >
         {children}
       </li>
@@ -39,7 +49,7 @@ function ListItem({ children, hoverable = false }: ListItemProps) {
 }
 
 type ListItemBodyProps = {
-  children:
+  children?:
     | React.ReactNode
     | CallableChildren<{ Filler: () => React.ReactNode }>;
 };

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -18,12 +18,17 @@ export function postFetch<ReqData>(path: string, body: ReqData) {
   });
 }
 
-export function putFetch<ReqData>(path: string, body: ReqData) {
+export function putFetch<ReqData>(
+  path: string,
+  body: ReqData,
+  options?: Omit<RequestInit, 'method' | 'headers' | 'body'>,
+) {
   return fetch(API_URL + path, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(body),
+    ...options,
   });
 }

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -2,8 +2,8 @@ const API_BASE_URL =
   process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
 const API_URL = `${API_BASE_URL}/api`;
 
-export async function getFetch(path: string) {
-  const res = await fetch(API_URL + path);
+export async function getFetch(path: string, options?: RequestInit) {
+  const res = await fetch(API_URL + path, options);
   if (res.ok) return res.json();
   // TODO error
 }

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -1,0 +1,29 @@
+const API_BASE_URL =
+  process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
+const API_URL = `${API_BASE_URL}/api`;
+
+export async function getFetch(path: string) {
+  const res = await fetch(API_URL + path);
+  if (res.ok) return res.json();
+  // TODO error
+}
+
+export function postFetch<ReqData>(path: string, body: ReqData) {
+  return fetch(API_URL + path, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+export function putFetch<ReqData>(path: string, body: ReqData) {
+  return fetch(API_URL + path, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/services/server-state/query-client-provider.tsx
+++ b/src/services/server-state/query-client-provider.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function GlobalQueryClientProvider({
+  children,
+}: React.PropsWithChildren) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // With SSR, we usually want to set some default staleTime above 0
+            // to avoid refetching immediately on the client
+            staleTime: 60 * 1000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/types/category.ts
+++ b/types/category.ts
@@ -1,12 +1,12 @@
 export type CategoryTheme =
-  | 'gray'
-  | 'red'
-  | 'yellow'
-  | 'green'
-  | 'blue'
-  | 'indigo'
-  | 'purple'
-  | 'pink';
+  | 'GRAY'
+  | 'RED'
+  | 'YELLOW'
+  | 'GREEN'
+  | 'BLUE'
+  | 'INDIGO'
+  | 'PURPLE'
+  | 'PINK';
 
 export type CategoryInput = {
   id?: string; // uuid


### PR DESCRIPTION
- `GET`, `POST`, `PUT` 메소드를 구현했다.
- Next.js가 확장한 fetch API로 request한다.
- 클라이언트에서 fetch하는 경우 TanStack Query를 사용한다.
  - 이 때, fetch가 하는 캐시와 TanStack Query가 하는 캐시 모두 신경써주어야 한다.
  - 휴먼 에러를 방지할 좋은 방법이 없을까 고민해봐야 할 듯
- prefetch가 필요할 때 서버 fetch한다.
- `POST`, `PUT`의 경우 Next.js 서버 액션으로 요청한다.