### PR TITLE
Request plans

### DIFF
--- a/src/app/plan/[id]/page.tsx
+++ b/src/app/plan/[id]/page.tsx
@@ -1,23 +1,42 @@
-'use client';
-
+import { revalidateTag } from 'next/cache';
+import { permanentRedirect } from 'next/navigation';
 import RoutinePlanForm from 'src/app/plan/form';
-import { RoutineInput } from 'types/routine';
+import { getFetch, putFetch } from 'src/services/fetch';
+import { Routine } from 'types/routine';
 
-export default function RoutinePlanUpdatePage() {
-  const handleSubmit = (input: RoutineInput) => {
-    console.log('update', input);
-  };
+export default async function RoutinePlanUpdatePage({
+  params: { id },
+}: {
+  params: { id: string };
+}) {
+  const routine: Routine = await getFetch(`/routine/${id}`, {
+    next: {
+      tags: ['routine', id],
+    },
+  });
+  async function update(formData: FormData) {
+    'use server';
+
+    const response = await putFetch(`/routine/${id}`, {
+      id,
+      name: formData.get('routiner-routine-name'),
+      repeatDays: formData.getAll('routiner-repeat-days').map(Number),
+      categoryId: formData.get('routiner-category-id'),
+    });
+
+    if (response.ok) {
+      revalidateTag(id);
+      revalidateTag('routines');
+      permanentRedirect('/plan');
+    } else throw new Error(await response.json());
+  }
 
   return (
     <main>
       <RoutinePlanForm
-        routine={{
-          id: '1',
-          name: '챌린저스 기상 미션하기',
-          repeatDays: [1, 2, 3, 4, 5],
-          categoryId: '1',
-        }}
-        onSubmit={handleSubmit}
+        action={update}
+        initialCategoryId={routine.category.id}
+        routine={routine}
       />
     </main>
   );

--- a/src/app/plan/form.tsx
+++ b/src/app/plan/form.tsx
@@ -8,12 +8,14 @@ import Form from 'src/components/form';
 import Toast from 'src/components/toast';
 import { useInputReducer } from 'src/hooks/useInputReducer';
 import { getCategories } from 'src/services/server-state/category';
-import { RoutineInput } from 'types/routine';
+import { Routine } from 'types/routine';
 
 type RoutinePlanFormProps = {
-  routine?: RoutineInput;
+  initialCategoryId: string;
+  routine?: Routine;
 } & React.FormHTMLAttributes<HTMLFormElement>;
 export default function RoutinePlanForm({
+  initialCategoryId,
   routine,
   onSubmit,
   ...props
@@ -25,7 +27,6 @@ export default function RoutinePlanForm({
     queryFn: getCategories,
   });
 
-  const initialCategory = routine?.categoryId || categories[0]?.id || '';
   const initialDays: { [key: number]: boolean } = {};
   const initialName = routine?.name || '';
   routine?.repeatDays.forEach((day) => (initialDays[day] = true));
@@ -33,7 +34,7 @@ export default function RoutinePlanForm({
   const [category, categoryDispatcher] = useInputReducer<
     string,
     HTMLLegendElement
-  >(initialCategory);
+  >(initialCategoryId);
   const [days, daysDispatcher] = useInputReducer<
     { [key: number]: boolean },
     HTMLLegendElement

--- a/src/app/plan/new/page.tsx
+++ b/src/app/plan/new/page.tsx
@@ -11,7 +11,6 @@ export default function RoutinePlanCreatePage() {
       repeatDays: formData.getAll('routiner-repeat-days').map(Number),
       categoryId: formData.get('routiner-category-id'),
     });
-
     if (response.ok) {
       permanentRedirect('/plan');
     } else throw new Error(await response.json());
@@ -19,7 +18,10 @@ export default function RoutinePlanCreatePage() {
 
   return (
     <main>
-      <RoutinePlanForm action={create} />
+      <RoutinePlanForm
+        action={create}
+        initialCategoryId={process.env.DEFAULT_CATEGORY_ID || ''}
+      />
     </main>
   );
 }

--- a/src/app/plan/new/page.tsx
+++ b/src/app/plan/new/page.tsx
@@ -1,16 +1,25 @@
-'use client';
-
+import { permanentRedirect } from 'next/navigation';
 import RoutinePlanForm from 'src/app/plan/form';
-import { RoutineInput } from 'types/routine';
+import { postFetch } from 'src/services/fetch';
 
 export default function RoutinePlanCreatePage() {
-  const handleSubmit = (input: RoutineInput) => {
-    console.log('create', input);
-  };
+  async function create(formData: FormData) {
+    'use server';
+
+    const response = await postFetch('/routine', {
+      name: formData.get('routiner-routine-name'),
+      repeatDays: formData.getAll('routiner-repeat-days').map(Number),
+      categoryId: formData.get('routiner-category-id'),
+    });
+
+    if (response.ok) {
+      permanentRedirect('/plan');
+    } else throw new Error(await response.json());
+  }
 
   return (
     <main>
-      <RoutinePlanForm onSubmit={handleSubmit} />
+      <RoutinePlanForm action={create} />
     </main>
   );
 }

--- a/src/app/setting/page.tsx
+++ b/src/app/setting/page.tsx
@@ -9,16 +9,7 @@ import Badge from 'src/components/badge';
 import Button from 'src/components/button';
 import Dialog from 'src/components/dialog';
 import List from 'src/components/list';
-import { getFetch } from 'src/services/fetch';
-import { Category } from 'types/category';
-
-function getList(): Promise<Category[]> {
-  return getFetch('/category', {
-    next: {
-      tags: ['categories'],
-    },
-  });
-}
+import { getCategories } from 'src/services/server-state/category';
 
 export default function SettingRootPage() {
   const router = useRouter();
@@ -26,7 +17,7 @@ export default function SettingRootPage() {
 
   const { data: categories = [], isPending } = useQuery({
     queryKey: ['categories'],
-    queryFn: getList,
+    queryFn: getCategories,
     enabled: categoryListOpened,
   });
 

--- a/src/services/server-state/category.ts
+++ b/src/services/server-state/category.ts
@@ -1,0 +1,10 @@
+import { getFetch } from 'src/services/fetch';
+import { Category } from 'types/category';
+
+export function getCategories(): Promise<Category[]> {
+  return getFetch('/category', {
+    next: {
+      tags: ['categories'],
+    },
+  });
+}

--- a/types/category.ts
+++ b/types/category.ts
@@ -8,12 +8,6 @@ export type CategoryTheme =
   | 'PURPLE'
   | 'PINK';
 
-export type CategoryInput = {
-  id?: string; // uuid
-  name: string;
-  theme: CategoryTheme;
-};
-
 export type Category = {
   id: string; // uuid
   name: string;

--- a/types/routine.ts
+++ b/types/routine.ts
@@ -1,12 +1,5 @@
 import { Category } from 'types/category';
 
-export type RoutineInput = {
-  id?: string; // uuid
-  name: string;
-  repeatDays: number[];
-  categoryId: string; // uuid
-};
-
 export type Routine = {
   id: string; // uuid
   name: string;


### PR DESCRIPTION
- `GET`, `POST`, `PUT` 메소드를 구현했다.
- 루틴 생성, 업데이트, 단일 조회에 서버 액션을 활용한다.
- 루틴 목록을 조회할 때 클라이언트 단에서 TanStack Query로 fetch한다.
- 루틴 form에서 사용하는 카테고리 목록도 클라이언트 단에서 fetch한다.
  - 카테고리 목록을 캐시한 게 있으면 활용하기 위해 클라이언트 fetch한다.
  - 이 때, 새 루틴 생성의 경우 default 카테고리를 initial 선택 값으로 갖는다.
  - 따라서 default 카테고리가 존재함을 서버가 보장해야 한다. (`process.env.DEFAULT_CATEGORY_ID`)