### PR TITLE
Show toast message while saving form

### DIFF
--- a/src/app/category/form.tsx
+++ b/src/app/category/form.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import { useRef, useState } from 'react';
 import Badge, { BADGE_STYLES, BadgeVariant } from 'src/components/badge';
-import Button from 'src/components/button';
 import Form from 'src/components/form';
 import Toast from 'src/components/toast';
 import { useInputReducer } from 'src/hooks/useInputReducer';
@@ -66,7 +65,7 @@ export default function RoutineCategoryForm({
   };
 
   return (
-    <Form onSubmit={handleSubmit} {...props}>
+    <Form onCancel={router.back} onSubmit={handleSubmit} {...props}>
       <div>
         <Form.Label
           htmlFor="routiner-category-name"
@@ -126,11 +125,6 @@ export default function RoutineCategoryForm({
           하나 이상 선택해야 해요.
         </Toast>
       </fieldset>
-      <Form.Footer>
-        <Button size="md" variant="secondary" onClick={() => router.back()}>
-          취소
-        </Button>
-      </Form.Footer>
     </Form>
   );
 }

--- a/src/app/plan/form.tsx
+++ b/src/app/plan/form.tsx
@@ -3,7 +3,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import Badge from 'src/components/badge';
-import Button from 'src/components/button';
 import Form from 'src/components/form';
 import Toast from 'src/components/toast';
 import { useInputReducer } from 'src/hooks/useInputReducer';
@@ -81,7 +80,7 @@ export default function RoutinePlanForm({
   };
 
   return (
-    <Form onSubmit={handleSubmit} {...props}>
+    <Form onCancel={router.back} onSubmit={handleSubmit} {...props}>
       <fieldset>
         <Form.Legend ref={categoryDispatcher.setRef}>루틴 카테고리</Form.Legend>
         <Toast
@@ -178,11 +177,6 @@ export default function RoutinePlanForm({
           }}
         />
       </div>
-      <Form.Footer>
-        <Button size="md" variant="secondary" onClick={() => router.back()}>
-          취소
-        </Button>
-      </Form.Footer>
     </Form>
   );
 }

--- a/src/components/form-footer.tsx
+++ b/src/components/form-footer.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import clsx from 'clsx';
+import { useState } from 'react';
+import { useFormStatus } from 'react-dom';
+import Button from 'src/components/button';
+import Toast from 'src/components/toast';
+
+type FormFooterProps = React.PropsWithChildren<{
+  onCancel?: React.MouseEventHandler<HTMLButtonElement>;
+}>;
+function FormFooter({ onCancel, children }: FormFooterProps) {
+  const { pending } = useFormStatus();
+  const [submitBtnRef, setSubmitBtnRef] = useState<HTMLButtonElement | null>(
+    null,
+  );
+
+  return (
+    <>
+      <div className="h-20" aria-hidden="true" />
+      <div
+        className={clsx(
+          'absolute bottom-0 left-0 right-0 h-20 px-6',
+          'flex items-center justify-end gap-x-6 border-t border-gray-900/10',
+        )}
+      >
+        <Button size="md" variant="secondary" onClick={onCancel}>
+          취소
+        </Button>
+        <Button
+          type="submit"
+          size="md"
+          variant="primary"
+          ref={setSubmitBtnRef}
+          disabled={pending}
+        >
+          저장
+        </Button>
+        <Toast
+          show={pending}
+          variant="warn"
+          options={{
+            placement: 'top',
+            reference: submitBtnRef,
+          }}
+          className="animate-bounce"
+        >
+          잠시만요, 저장하고 있어요.
+        </Toast>
+      </div>
+    </>
+  );
+}
+
+export default FormFooter;

--- a/src/components/form.tsx
+++ b/src/components/form.tsx
@@ -1,14 +1,19 @@
 import clsx from 'clsx';
 import { forwardRef } from 'react';
-import Button from 'src/components/button';
+import FormFooter from 'src/components/form-footer';
 
-function FormRoot({
-  children,
-  ...props
-}: React.PropsWithChildren<React.FormHTMLAttributes<HTMLFormElement>>) {
+type FormRootProps = React.PropsWithChildren<
+  React.FormHTMLAttributes<HTMLFormElement> & {
+    onCancel?: React.MouseEventHandler<HTMLButtonElement>;
+  }
+>;
+function FormRoot({ children, onCancel, ...props }: FormRootProps) {
   return (
     <form {...props}>
-      <div className="space-y-8 px-10 pt-8">{children}</div>
+      <div className="space-y-8 px-10 pt-8">
+        {children}
+        <FormFooter onCancel={onCancel} />
+      </div>
     </form>
   );
 }
@@ -101,25 +106,6 @@ function FormLegend(
     >
       {children}
     </legend>
-  );
-}
-
-function FormFooter({ children }: React.PropsWithChildren) {
-  return (
-    <>
-      <div className="h-20" aria-hidden="true" />
-      <div
-        className={clsx(
-          'absolute bottom-0 left-0 right-0 h-20 px-6',
-          'flex items-center justify-end gap-x-6 border-t border-gray-900/10',
-        )}
-      >
-        {children}
-        <Button type="submit" size="md" variant="primary">
-          저장
-        </Button>
-      </div>
-    </>
   );
 }
 


### PR DESCRIPTION
## 어떤 결과를 얻기 위한 작업이었나요?
> ex. 어떤 문제였는지와 그 원인, 요구 사항 등

- 카테고리 form, 루틴 form의 중복 submission 방지

## 원하는 결과를 얻기 위해 어떻게 했나요?
> ex. 무엇을 고쳤는지, 요구 사항을 어떻게 구현했는지 등

- `useFormStatus` 훅의 form submission 상태에 따라 submit 버튼 disable, 통통 튀는 Toast 컴포넌트 렌더링

## 추가로 남기고 싶은 내용이 있다면 적어주세요. (선택)
> ex. 화면 스크린샷, 동작에 대한 설명, 진행 과정에서 들었던 생각 등

- 클라이언트 컴포넌트 FormFooter 생성
  - `'use client'`가 필요해서 서버 컴포넌트만 모아둔 form.ts 파일로부터 분리한건데 의미있는 차이가 있나 궁금하다.
- Toast 컴포넌트 리팩토링
  - 위치를 transform 스타일로 조정하도록 옵션 수정
  - `createPortal`을 이용해 `document.body` 하위 노드로 렌더링 (Use createPortal to render a Toast component)

### 비디오로 동작 확인하기

https://github.com/j2e4/routiner/assets/40452288/8de59a7b-4baf-4880-9536-c76a3d5ded2f

