### PR TITLE
Classify routine lists using tabs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@tanstack/react-query": "^5.17.19",
         "@tanstack/react-query-devtools": "^5.17.21",
         "clsx": "^2.0.0",
+        "lodash": "^4.17.21",
         "next": "^14.1.4",
         "react": "^18",
         "react-dom": "^18"
@@ -23,6 +24,7 @@
         "@testing-library/jest-dom": "^6.1.5",
         "@testing-library/react": "^14.1.2",
         "@types/jest": "^29.5.11",
+        "@types/lodash": "^4.17.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -2076,6 +2078,12 @@
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -6633,8 +6641,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tanstack/react-query": "^5.17.19",
     "@tanstack/react-query-devtools": "^5.17.21",
     "clsx": "^2.0.0",
+    "lodash": "^4.17.21",
     "next": "^14.1.4",
     "react": "^18",
     "react-dom": "^18"
@@ -25,6 +26,7 @@
     "@testing-library/jest-dom": "^6.1.5",
     "@testing-library/react": "^14.1.2",
     "@types/jest": "^29.5.11",
+    "@types/lodash": "^4.17.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -1,30 +1,23 @@
 'use client';
 
+import { Tab } from '@headlessui/react';
 import { CheckIcon, EllipsisVerticalIcon } from '@heroicons/react/24/outline';
 import { useQuery } from '@tanstack/react-query';
+import clsx from 'clsx';
+import { useState } from 'react';
 import Badge from 'src/components/badge';
 import Dropdown from 'src/components/dropdown';
 import List from 'src/components/list';
+import {
+  ROUTINE_CHECK_ITEMS,
+  ROUTINE_CHECK_TABS,
+  RoutineCheck,
+} from 'src/constants/routine';
 import { getFetch, postFetch } from 'src/services/fetch';
 import { toDateStr } from 'src/utils/date-str';
-import { ToCheckRoutine } from 'types/routine';
-
-const ROUTINE_CHECKS = [
-  { text: '완료하기', value: 1 },
-  { text: '오늘은 건너뛰기', value: 2 },
-  { text: '오늘 안 하기', value: 3 },
-];
-
-function getList(date: string): Promise<ToCheckRoutine[]> {
-  return getFetch(`/daily?date=${date}`, {
-    next: {
-      tags: ['daily_routines'],
-    },
-  });
-}
+import { DailyRoutine } from 'types/routine';
 
 export default function RoutineToday() {
-  const reqDateStr = toDateStr(new Date());
   const {
     data = [],
     isPending,
@@ -32,9 +25,28 @@ export default function RoutineToday() {
     refetch,
   } = useQuery({
     queryKey: ['daily_routines'],
-    queryFn: () => getList(reqDateStr),
+    queryFn: () => {
+      const date = toDateStr(new Date());
+      return getFetch('/daily', {
+        params: {
+          date,
+        },
+        next: {
+          tags: ['daily_routines'],
+        },
+      });
+    },
   });
-  const routines = data.filter((routine) => Number(routine.routineCheck) === 0);
+
+  const [tabIndex, setTabIndex] = useState(RoutineCheck.ToCheck);
+  const tab = ROUTINE_CHECK_TABS[tabIndex];
+  const tabData = new Map<RoutineCheck, DailyRoutine[]>();
+  data.forEach((item: DailyRoutine) => {
+    const check = Number(item.routineCheck);
+    const arr = tabData.get(check) || [];
+    tabData.set(check, arr.concat(item));
+  });
+  const routines = tabData.get(tab.key) || [];
 
   let displayMessage = '';
   if (isPending) displayMessage = '오늘 실천할 루틴을 불러오는 중이에요.';
@@ -51,7 +63,39 @@ export default function RoutineToday() {
 
   return (
     <main>
-      <List border="b">
+      <Tab.Group selectedIndex={tabIndex} onChange={setTabIndex}>
+        <Tab.List className="-mb-px flex justify-between px-6 md:justify-normal md:space-x-6 md:px-8">
+          {ROUTINE_CHECK_TABS.map((tab) => (
+            <Tab
+              key={tab.key}
+              className={({ selected }) =>
+                clsx(
+                  'flex whitespace-nowrap border-b-2 px-1 py-4 text-sm font-medium outline-none md:px-2',
+                  selected && 'border-theme-neutral-200 text-gray-900',
+                  !selected &&
+                    'border-transparent text-gray-500 hover:border-gray-200 hover:text-gray-700',
+                )
+              }
+            >
+              {({ selected }) => (
+                <>
+                  {tab.name}
+                  <span
+                    className={clsx(
+                      'ml-3 rounded-full px-2.5 py-0.5 text-xs font-medium',
+                      selected && 'bg-theme-neutral-100',
+                      !selected && 'bg-gray-100 text-gray-900',
+                    )}
+                  >
+                    {tabData.get(tab.key)?.length || 0}
+                  </span>
+                </>
+              )}
+            </Tab>
+          ))}
+        </Tab.List>
+      </Tab.Group>
+      <List>
         {displayMessage !== '' && (
           <List.Item>
             <List.ItemBody className="text-center">
@@ -68,27 +112,29 @@ export default function RoutineToday() {
               </List.ItemBodyText>
             </List.ItemBody>
             <List.ItemTail className="flex items-center space-x-1">
-              <Dropdown>
-                <Dropdown.Button variant="secondary" size="sm">
-                  <CheckIcon
-                    className="h-3.5 w-3.5 text-gray-400"
-                    aria-hidden="true"
-                  />
-                  <span className="sr-only">
-                    Update whether this routine is done or not
-                  </span>
-                </Dropdown.Button>
-                <Dropdown.Menu>
-                  {ROUTINE_CHECKS.map(({ text, value }) => (
-                    <Dropdown.ButtonItem
-                      key={text}
-                      onClick={() => update(routine.id, value)}
-                    >
-                      {text}
-                    </Dropdown.ButtonItem>
-                  ))}
-                </Dropdown.Menu>
-              </Dropdown>
+              {tab.updatable && (
+                <Dropdown>
+                  <Dropdown.Button variant="secondary" size="sm">
+                    <CheckIcon
+                      className="h-3.5 w-3.5 text-gray-400"
+                      aria-hidden="true"
+                    />
+                    <span className="sr-only">
+                      Update whether this routine is done or not
+                    </span>
+                  </Dropdown.Button>
+                  <Dropdown.Menu>
+                    {ROUTINE_CHECK_ITEMS.map(({ name, value }) => (
+                      <Dropdown.ButtonItem
+                        key={name}
+                        onClick={() => update(routine.id, value)}
+                      >
+                        {name}
+                      </Dropdown.ButtonItem>
+                    ))}
+                  </Dropdown.Menu>
+                </Dropdown>
+              )}
               <Dropdown>
                 <Dropdown.Button variant="secondary" size="sm">
                   <EllipsisVerticalIcon

--- a/src/app/routine/page.tsx
+++ b/src/app/routine/page.tsx
@@ -123,20 +123,22 @@ export default function RoutineToday() {
                           </Dropdown.Menu>
                         </Dropdown>
                       )}
-                      <Dropdown>
-                        <Dropdown.Button variant="secondary" size="sm">
-                          <EllipsisVerticalIcon
-                            className="h-3.5 w-3.5 text-gray-400"
-                            aria-hidden="true"
-                          />
-                          <span className="sr-only">Manage this routine</span>
-                        </Dropdown.Button>
-                        <Dropdown.Menu>
-                          <Dropdown.LinkItem href={`/plan/${routine.id}`}>
-                            수정하기
-                          </Dropdown.LinkItem>
-                        </Dropdown.Menu>
-                      </Dropdown>
+                      {tab.updatable && (
+                        <Dropdown>
+                          <Dropdown.Button variant="secondary" size="sm">
+                            <EllipsisVerticalIcon
+                              className="h-3.5 w-3.5 text-gray-400"
+                              aria-hidden="true"
+                            />
+                            <span className="sr-only">Manage this routine</span>
+                          </Dropdown.Button>
+                          <Dropdown.Menu>
+                            <Dropdown.LinkItem href={`/plan/${routine.id}`}>
+                              수정하기
+                            </Dropdown.LinkItem>
+                          </Dropdown.Menu>
+                        </Dropdown>
+                      )}
                     </List.ItemTail>
                   </List.Item>
                 ))}

--- a/src/components/list.tsx
+++ b/src/components/list.tsx
@@ -5,7 +5,7 @@ import { useHoverable } from 'src/hooks/useHoverable';
 import { CallableChildren } from 'types/props';
 
 type ListRootProps = React.PropsWithChildren<{
-  border: 't' | 'b' | 'y';
+  border?: 't' | 'b' | 'y';
   className?: string;
 }>;
 function ListRoot({ border = 'y', children, className }: ListRootProps) {

--- a/src/components/routine/TabListPlaceholder.tsx
+++ b/src/components/routine/TabListPlaceholder.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query';
 import List from 'src/components/list';
-import { RoutineCheck } from 'src/constants/routine';
+import { DAILY_ROUTINE_TABS, RoutineCheck } from 'src/constants/routine';
 import { DailyRoutineTab } from 'types/routine';
 
 const PendingMessage = {
@@ -45,17 +45,16 @@ export default function TabListPlaceholder({
   ]);
 
   const status = queryState?.status;
-  const tab = queryData?.[tabIndex];
-
-  // query 문제
-  if (tab === undefined) return createListItem('탭 정보를 찾을 수 없어요.');
-  if (tab.routines === undefined)
-    return createListItem('루틴 목록을 찾을 수 없어요.');
+  const tab = queryData?.[tabIndex] ?? DAILY_ROUTINE_TABS[tabIndex];
 
   // query state 관련
   if (status === 'pending') return createListItem(PendingMessage[tab.id]);
-  if (status === 'success' && tab.routines.length === 0)
-    return createListItem(EmptyListMessage[tab.id]);
+  if (status === 'success' && tab.routines?.length === 0)
+    return createListItem(EmptyListMessage[tab?.id]);
+
+  // query 문제
+  if (tab.routines === undefined)
+    return createListItem('루틴 목록을 찾을 수 없어요.');
 
   return null;
 }

--- a/src/components/routine/TabListPlaceholder.tsx
+++ b/src/components/routine/TabListPlaceholder.tsx
@@ -1,0 +1,61 @@
+import { useQueryClient } from '@tanstack/react-query';
+import List from 'src/components/list';
+import { RoutineCheck } from 'src/constants/routine';
+import { DailyRoutineTab } from 'types/routine';
+
+const PendingMessage = {
+  [RoutineCheck.ToCheck]: '오늘 실천할 루틴을 불러오는 중이에요.',
+  [RoutineCheck.Checked]: '오늘 완료한 루틴을 불러오는 중이에요.',
+  [RoutineCheck.Skipped]: '오늘 건너뛴 루틴을 불러오는 중이에요.',
+  [RoutineCheck.NoCheck]: '오늘 안 하기로 한 루틴을 불러오는 중이에요.',
+};
+const EmptyListMessage = {
+  [RoutineCheck.ToCheck]: '오늘 루틴을 모두 완료했어요.',
+  [RoutineCheck.Checked]: '아직 완료한 루틴이 없어요.',
+  [RoutineCheck.Skipped]: '오늘 건너뛴 루틴이 없어요.',
+  [RoutineCheck.NoCheck]: '오늘 안 하기로 한 루틴이 없어요.',
+};
+
+function createListItem(message: string) {
+  return (
+    <List.Item>
+      <List.ItemBody className="text-center">
+        <List.ItemBodyText>{message}</List.ItemBodyText>
+      </List.ItemBody>
+    </List.Item>
+  );
+}
+
+type TabListPlaceholderProps = {
+  tabIndex: number;
+};
+
+/**
+ * DailyRoutine 목록을 fetch 중이거나 데이터가 없을 때 보여주는 placeholder
+ */
+export default function TabListPlaceholder({
+  tabIndex,
+}: TabListPlaceholderProps) {
+  const queryClient = useQueryClient();
+  const queryState = queryClient.getQueryState<DailyRoutineTab[]>([
+    'daily_routines',
+  ]);
+  const queryData = queryClient.getQueryData<DailyRoutineTab[]>([
+    'daily_routines',
+  ]);
+
+  const status = queryState?.status;
+  const tab = queryData?.[tabIndex];
+
+  // query 문제
+  if (tab === undefined) return createListItem('탭 정보를 찾을 수 없어요.');
+  if (tab.routines === undefined)
+    return createListItem('루틴 목록을 찾을 수 없어요.');
+
+  // query state 관련
+  if (status === 'pending') return createListItem(PendingMessage[tab.id]);
+  if (status === 'success' && tab.routines.length === 0)
+    return createListItem(EmptyListMessage[tab.id]);
+
+  return null;
+}

--- a/src/constants/routine.ts
+++ b/src/constants/routine.ts
@@ -15,22 +15,26 @@ export const ROUTINE_CHECK_TABS = [
   {
     key: RoutineCheck.ToCheck,
     name: '미완료',
+    pendingMessage: '오늘 실천할 루틴을 불러오는 중이에요.',
     emptyListMessage: '오늘 루틴을 모두 완료했어요.',
     updatable: true,
   },
   {
     key: RoutineCheck.Checked,
     name: '완료',
+    pendingMessage: '오늘 완료한 루틴을 불러오는 중이에요.',
     emptyListMessage: '아직 완료한 루틴이 없어요.',
   },
   {
     key: RoutineCheck.Skipped,
     name: '건너뜀',
+    pendingMessage: '오늘 건너뛴 루틴을 불러오는 중이에요.',
     emptyListMessage: '오늘 건너뛴 루틴이 없어요.',
   },
   {
     key: RoutineCheck.NoCheck,
     name: '안 함',
+    pendingMessage: '오늘 안 하기로 한 루틴을 불러오는 중이에요.',
     emptyListMessage: '오늘 안 하기로 한 루틴이 없어요.',
   },
 ];

--- a/src/constants/routine.ts
+++ b/src/constants/routine.ts
@@ -1,0 +1,36 @@
+export enum RoutineCheck {
+  ToCheck,
+  Checked,
+  Skipped,
+  NoCheck,
+}
+
+export const ROUTINE_CHECK_ITEMS = [
+  { name: '완료하기', value: RoutineCheck.Checked },
+  { name: '오늘은 건너뛰기', value: RoutineCheck.Skipped },
+  { name: '오늘 안 하기', value: RoutineCheck.NoCheck },
+];
+
+export const ROUTINE_CHECK_TABS = [
+  {
+    key: RoutineCheck.ToCheck,
+    name: '미완료',
+    emptyListMessage: '오늘 루틴을 모두 완료했어요.',
+    updatable: true,
+  },
+  {
+    key: RoutineCheck.Checked,
+    name: '완료',
+    emptyListMessage: '아직 완료한 루틴이 없어요.',
+  },
+  {
+    key: RoutineCheck.Skipped,
+    name: '건너뜀',
+    emptyListMessage: '오늘 건너뛴 루틴이 없어요.',
+  },
+  {
+    key: RoutineCheck.NoCheck,
+    name: '안 함',
+    emptyListMessage: '오늘 안 하기로 한 루틴이 없어요.',
+  },
+];

--- a/src/constants/routine.ts
+++ b/src/constants/routine.ts
@@ -18,6 +18,7 @@ export const DAILY_ROUTINE_TABS: DailyRoutineTab[] = [
     id: RoutineCheck.ToCheck,
     name: '미완료',
     checkable: true,
+    updatable: true,
   },
   { id: RoutineCheck.Checked, name: '완료' },
   { id: RoutineCheck.Skipped, name: '건너뜀' },

--- a/src/constants/routine.ts
+++ b/src/constants/routine.ts
@@ -1,3 +1,5 @@
+import { DailyRoutineTab } from 'types/routine';
+
 export enum RoutineCheck {
   ToCheck,
   Checked,
@@ -11,30 +13,13 @@ export const ROUTINE_CHECK_ITEMS = [
   { name: '오늘 안 하기', value: RoutineCheck.NoCheck },
 ];
 
-export const ROUTINE_CHECK_TABS = [
+export const DAILY_ROUTINE_TABS: DailyRoutineTab[] = [
   {
-    key: RoutineCheck.ToCheck,
+    id: RoutineCheck.ToCheck,
     name: '미완료',
-    pendingMessage: '오늘 실천할 루틴을 불러오는 중이에요.',
-    emptyListMessage: '오늘 루틴을 모두 완료했어요.',
-    updatable: true,
+    checkable: true,
   },
-  {
-    key: RoutineCheck.Checked,
-    name: '완료',
-    pendingMessage: '오늘 완료한 루틴을 불러오는 중이에요.',
-    emptyListMessage: '아직 완료한 루틴이 없어요.',
-  },
-  {
-    key: RoutineCheck.Skipped,
-    name: '건너뜀',
-    pendingMessage: '오늘 건너뛴 루틴을 불러오는 중이에요.',
-    emptyListMessage: '오늘 건너뛴 루틴이 없어요.',
-  },
-  {
-    key: RoutineCheck.NoCheck,
-    name: '안 함',
-    pendingMessage: '오늘 안 하기로 한 루틴을 불러오는 중이에요.',
-    emptyListMessage: '오늘 안 하기로 한 루틴이 없어요.',
-  },
+  { id: RoutineCheck.Checked, name: '완료' },
+  { id: RoutineCheck.Skipped, name: '건너뜀' },
+  { id: RoutineCheck.NoCheck, name: '안 함' },
 ];

--- a/src/services/fetch.ts
+++ b/src/services/fetch.ts
@@ -2,7 +2,24 @@ const API_BASE_URL =
   process.env.API_BASE_URL || process.env.NEXT_PUBLIC_API_BASE_URL;
 const API_URL = `${API_BASE_URL}/api`;
 
-export async function getFetch(path: string, options?: RequestInit) {
+interface GetRequestOptions extends RequestInit {
+  params?: Record<string, string | number | boolean>;
+}
+
+export async function getFetch(
+  path: string,
+  { params, ...options }: GetRequestOptions,
+) {
+  if (params !== undefined) {
+    const searchParams = new URLSearchParams();
+    for (const key in params) {
+      const value = String(params[key]);
+      searchParams.append(key, value);
+    }
+    path += '?';
+    path += searchParams.toString();
+  }
+
   const res = await fetch(API_URL + path, options);
   if (res.ok) return res.json();
   // TODO error

--- a/types/routine.ts
+++ b/types/routine.ts
@@ -14,3 +14,10 @@ export type DailyRoutine = {
   routineCheck: RoutineCheck | null; // null은 0으로 취급한다.
   category: Category;
 };
+
+export type DailyRoutineTab = {
+  id: RoutineCheck;
+  name: string;
+  routines?: DailyRoutine[]; // server state
+  checkable?: boolean;
+};

--- a/types/routine.ts
+++ b/types/routine.ts
@@ -1,3 +1,4 @@
+import { RoutineCheck } from 'src/constants/routine';
 import { Category } from 'types/category';
 
 export type Routine = {
@@ -7,9 +8,9 @@ export type Routine = {
   category: Category;
 };
 
-export type ToCheckRoutine = {
-  id: string;
+export type DailyRoutine = {
+  id: string; // uuid
   name: string;
-  routineCheck: number | null;
+  routineCheck: RoutineCheck | null; // null은 0으로 취급한다.
   category: Category;
 };

--- a/types/routine.ts
+++ b/types/routine.ts
@@ -20,4 +20,5 @@ export type DailyRoutineTab = {
   name: string;
   routines?: DailyRoutine[]; // server state
   checkable?: boolean;
+  updatable?: boolean;
 };


### PR DESCRIPTION
## 어떤 결과를 얻기 위한 작업이었나요?
> ex. 어떤 문제였는지와 그 원인, 요구 사항 등

- `실천하기` 메뉴에 `루틴 실천 여부`로 목록을 구분하는 탭 추가

## 원하는 결과를 얻기 위해 어떻게 했나요?
> ex. 무엇을 고쳤는지, 요구 사항을 어떻게 구현했는지 등

- Headless UI의 `Tab` 컴포넌트 활용
- 서버 상태 fetch 로직이 실천 여부로 구분한 루틴 목록을 포함하는 탭 데이터를 반환하도록 수정 (AS-IS: 전체 루틴 목록 반환)
- 탭 별로 플레이스홀더를 다르게 렌더링하기 위해 `TabListPlaceholder` 컴포넌트 생성

## 추가로 남기고 싶은 내용이 있다면 적어주세요. (선택)
> ex. 화면 스크린샷, 동작에 대한 설명, 진행 과정에서 들었던 생각 등

- 서버 상태를 fetch하는 시도가 모두 에러일 때 placeholder가 리렌더링되지 않는 문제가 있다. 
- 루틴 실천 여부가 완료, 건너뜀, 안 함일 때 업데이트를 막았다. 기존에 지원하고 있던 동작까지만 일단 지원하기 위해

### 스크린샷
<img src="https://github.com/j2e4/routiner/assets/40452288/2a48caf9-7696-43ac-a8c1-d056275566be" alt="미완료" width="360" height="640"/>
<img src="https://github.com/j2e4/routiner/assets/40452288/a4a1586f-d257-4efa-a463-33fc655d26f9" alt="완료" width="360" height="640"/>
<img src="https://github.com/j2e4/routiner/assets/40452288/293aee44-206c-41c7-91e5-718d251fa91a" alt="건너뜀" width="360" height="640"/>
<img src="https://github.com/j2e4/routiner/assets/40452288/fa7de1d5-dcb8-4ade-a4f0-49fa3b730d91" alt="안 함" width="360" height="640"/>
